### PR TITLE
Make some internal state accessible. (#22)

### DIFF
--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -21,8 +21,10 @@ namespace SQLCover
         private readonly bool _logging;
         private readonly SourceGateway _source;
         private CoverageResult _result;
-        public const short TIMEOUT_EXPIRED = -2; //From TdsEnums
 
+        public const short TIMEOUT_EXPIRED = -2; //From TdsEnums
+        public SqlCoverException Exception { get; private set; } = null;
+        public bool IsStarted { get; private set; } = false;
 
         private TraceController _trace;
 
@@ -59,17 +61,22 @@ namespace SQLCover
             _database = new DatabaseGateway(connectionString, databaseName);
             _source = new DatabaseSourceGateway(_database);
         }
-                public bool Start()
+
+        public bool Start()
         {
+            Exception = null;
             try
             {
                 _trace = new TraceControllerBuilder().GetTraceController(_database, _databaseName, _traceType);
                 _trace.Start();
+                IsStarted = true;
                 return true;
             }
             catch (Exception ex)
             {
                 Debug("Error starting trace: {0}", ex);
+                Exception = new SqlCoverException("SQL Cover failed to start.", ex);
+                IsStarted = false;
                 return false;
             }
         }
@@ -85,6 +92,11 @@ namespace SQLCover
 
         public CoverageResult Stop()
         {
+            if(!IsStarted)
+                throw new SqlCoverException("SQL Cover was not started, or did not start correctly.");
+
+            IsStarted = false;
+
             WaitForTraceMaxLatency();
 
             var results = StopInternal();
@@ -201,7 +213,7 @@ namespace SQLCover
         private void GenerateResults(List<string> filter, List<string> xml)
         {
             var batches = _source.GetBatches(filter);
-            _result = new CoverageResult(batches, xml, _databaseName);
+            _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource);
         }
 
         public CoverageResult Results()

--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -14,14 +14,17 @@ namespace SQLCover
     public class CoverageResult : CoverageSummary
     {
         private readonly IEnumerable<Batch> _batches;
-        private readonly string _database;
+
+        public string DatabaseName { get; }
+        public string DataSource { get; }
 
         private readonly StatementChecker _statementChecker = new StatementChecker();
 
-        public CoverageResult(IEnumerable<Batch> batches, List<string> xml, string database)
+        public CoverageResult(IEnumerable<Batch> batches, List<string> xml, string database, string dataSource)
         {
             _batches = batches;
-            _database = database;
+            DatabaseName = database;
+            DataSource = dataSource;
             var parser = new EventsParser(xml);
 
             var statement = parser.GetNextStatement();
@@ -179,8 +182,8 @@ namespace SQLCover
                 , statements, coveredStatements, coveredStatements / (float) statements * 100.0);
 
             builder.Append("<Module hash=\"ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE\">");
-            builder.AppendFormat("<FullName>{0}</FullName>", _database);
-            builder.AppendFormat("<ModuleName>{0}</ModuleName>", _database);
+            builder.AppendFormat("<FullName>{0}</FullName>", DatabaseName);
+            builder.AppendFormat("<ModuleName>{0}</ModuleName>", DatabaseName);
 
             var fileMap = new Dictionary<string, int>();
             var i = 1;

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -9,6 +9,8 @@ namespace SQLCover.Gateway
     {
         private readonly string _connectionString;
         private readonly string _databaseName;
+        private readonly SqlConnectionStringBuilder _connectionStringBuilder;
+        public string DataSource { get { return _connectionStringBuilder.DataSource; } }
 
         public DatabaseGateway()
         {
@@ -18,8 +20,9 @@ namespace SQLCover.Gateway
         {
             _connectionString = connectionString;
             _databaseName = databaseName;
+            _connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
         }
-
+        
         public virtual string GetString(string query)
         {
             using (var conn = new SqlConnection(_connectionString))

--- a/src/SQLCover/SQLCover/SqlCoverException.cs
+++ b/src/SQLCover/SQLCover/SqlCoverException.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace SQLCover
 {
     [Serializable]
-    internal class SqlCoverException : Exception
+    public class SqlCoverException : Exception
     {
         public SqlCoverException()
         {


### PR DESCRIPTION
* Can check to see if CodeCoverage is running.
* Can access exceptions handled internally by SQLCover.
* Results object reports the data source the results came from.

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
