### PR TITLE
Don't crash and burn when object_name() returns a null

### DIFF
--- a/nuspec/SqlCover.nuspec
+++ b/nuspec/SqlCover.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>RedGate.ThirdParty.SqlCover</id>
-    <version>1.0.15.0</version>
+    <version>1.0.19.0</version>
     <title>SQL Cover</title>
     <authors>Ed Elliott</authors>
     <owners>Ed Elliott</owners>
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Code coverage tool for SQL Server 2008+</description>
     <releaseNotes></releaseNotes>
-    <copyright>Copyright 2016-2017</copyright>
+    <copyright>Copyright 2016-2018</copyright>
     <tags>sql tsqlt test code coverage</tags>
 	<references>
 		<reference file="RedGate.ThirdParty.SQLCover.dll" />

--- a/nuspec/SqlCover.nuspec
+++ b/nuspec/SqlCover.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>RedGate.ThirdParty.SqlCover</id>
-    <version>1.0.19.0</version>
+    <version>1.0.20.0</version>
     <title>SQL Cover</title>
     <authors>Ed Elliott</authors>
     <owners>Ed Elliott</owners>

--- a/nuspec/push.bat
+++ b/nuspec/push.bat
@@ -1,0 +1,1 @@
+nuget.exe push RedGate.ThirdParty.SqlCover.1.0.19.0.nupkg -apikey VSTS -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json

--- a/nuspec/push.bat
+++ b/nuspec/push.bat
@@ -1,1 +1,1 @@
-nuget.exe push RedGate.ThirdParty.SqlCover.1.0.19.0.nupkg -apikey VSTS -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json
+nuget.exe push RedGate.ThirdParty.SqlCover.1.0.20.0.nupkg -apikey VSTS -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json

--- a/nuspec/push.txt
+++ b/nuspec/push.txt
@@ -1,1 +1,0 @@
-nuget.exe push RedGate.ThirdParty.SqlCover.1.0.12.0.nupkg -apikey VSTS -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -45,10 +45,9 @@ public IEnumerable<Batch> GetBatches(List<string> objectFilter)
             var table =
                 _databaseGateway.GetRecords(
                     @"
-select object_id, '[' + object_schema_name(object_id) + '].[' + object_name(object_id) + ']' as object_name, definition, uses_quoted_identifier 
+select object_id, ISNULL('[' + object_schema_name(object_id) + '].[' + object_name(object_id) + ']', 'Object ' + CAST(object_id as nvarchar(12))) as object_name, definition, uses_quoted_identifier 
 from sys.sql_modules 
 where object_id not in (select object_id from sys.objects where type = 'IF')
-and object_name(object_id) is not null
 ");
 
             var batches = new List<Batch>();
@@ -104,11 +103,10 @@ and object_name(object_id) is not null
             var table =
                 _databaseGateway.GetRecords(
                     @"
-select '[' + object_schema_name(object_id) + '].[' + object_name(object_id) + ']' as object_name 
+select ISNULL('[' + object_schema_name(object_id) + '].[' + object_name(object_id) + ']', 'Object ' + CAST(object_id as nvarchar(12))) as object_name 
 from sys.sql_modules 
 where object_id not in (select object_id from sys.objects where type = 'IF') 
 and definition is null
-and object_name(object_id) is not null
 ");
 
 
@@ -136,12 +134,11 @@ and object_name(object_id) is not null
         {
             var tSQLtObjects =
                 _databaseGateway.GetRecords(@"
-select  '[' + object_schema_name(object_id) + '].[' + object_name(object_id) + ']' as object_name 
+select  ISNULL('[' + object_schema_name(object_id) + '].[' + object_name(object_id) + ']', 'Object ' + CAST(object_id as nvarchar(12))) as object_name 
 from sys.procedures
 where schema_id in (
     select major_id from sys.extended_properties ep
-    where class_desc = 'SCHEMA' and name = 'tSQLt.TestClass' )
-and object_name(object_id) is not null");
+    where class_desc = 'SCHEMA' and name = 'tSQLt.TestClass' )");
 
             var excludedObjects = new List<string>();
 


### PR DESCRIPTION
Fixes: When object_name(objectid) returns DbNull because of lack of permissions to interrogate the object, SqlCover crashed on trying to generate its report.

Changes proposed in this pull request:

Ignore objects for which this is the case, as we can't get a meaningful report for them.

Has been tested on (remove any that don't apply):

SQL Server 2014