### PR TITLE
Use SQL Server 2017 parser for 2017 instances

### DIFF
--- a/nuspec/SqlCover.nuspec
+++ b/nuspec/SqlCover.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>RedGate.ThirdParty.SqlCover</id>
-    <version>1.0.20.0</version>
+    <version>1.0.21.0</version>
     <title>SQL Cover</title>
     <authors>Ed Elliott</authors>
     <owners>Ed Elliott</owners>

--- a/nuspec/push.bat
+++ b/nuspec/push.bat
@@ -1,1 +1,1 @@
-nuget.exe push RedGate.ThirdParty.SqlCover.1.0.20.0.nupkg -apikey VSTS -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json
+nuget.exe push RedGate.ThirdParty.SqlCover.1.0.21.0.nupkg -apikey VSTS -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json

--- a/src/SQLCover/SQLCover/Objects/SqlServerVersion.cs
+++ b/src/SQLCover/SQLCover/Objects/SqlServerVersion.cs
@@ -6,6 +6,7 @@
         Sql100,
         Sql110,
         Sql120,
-        Sql130
+        Sql130,
+        Sql140
     }
 }

--- a/src/SQLCover/SQLCover/Parsers/TSqlParserBuilder.cs
+++ b/src/SQLCover/SQLCover/Parsers/TSqlParserBuilder.cs
@@ -25,6 +25,9 @@ namespace SQLCover.Parsers
                 case SqlServerVersion.Sql130:
                     return new TSql130Parser(quoted);
 
+                case SqlServerVersion.Sql140:
+                    return new TSql140Parser(quoted);
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(version), version, null);
             }

--- a/src/SQLCover/SQLCover/Properties/AssemblyInfo.cs
+++ b/src/SQLCover/SQLCover/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.0.4.0")]
-[assembly: AssemblyFileVersion("0.0.4.0")]
+[assembly: AssemblyVersion("1.0.21.0")]
+[assembly: AssemblyFileVersion("1.0.21.0")]

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -28,7 +28,7 @@ namespace SQLCover.Source
                 return res;
             }
 
-            return SqlServerVersion.Sql130;
+            return SqlServerVersion.Sql140;
         }
 
 

--- a/src/SQLCover/test/SQLCover.UnitTests/Source/DatabaseSourceGatewayTests.cs
+++ b/src/SQLCover/test/SQLCover.UnitTests/Source/DatabaseSourceGatewayTests.cs
@@ -19,6 +19,7 @@ namespace SQLCover.UnitTests.Source
         [TestCase(SqlServerVersion.Sql110)]
         [TestCase(SqlServerVersion.Sql120)]
         [TestCase(SqlServerVersion.Sql130)]
+        [TestCase(SqlServerVersion.Sql140)]
         public void GetVersion_Detects_SQL_Version(SqlServerVersion expected)
         {
             var gateway = GetGateway(expected);
@@ -46,6 +47,9 @@ namespace SQLCover.UnitTests.Source
                     break;
                 case SqlServerVersion.Sql130:
                     gateway.Setup(p => p.GetString(It.IsAny<string>())).Returns("130");
+                    break;
+                case SqlServerVersion.Sql140:
+                    gateway.Setup(p => p.GetString(It.IsAny<string>())).Returns("140");
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(expected), expected, null);


### PR DESCRIPTION
For some reason we never used the parser for SQL Server 2017, even though it was available. I guess if you're using the latest syntax then there's a chance it could trip up on the older parser, so it makes sense to ensure we're using the correct one.

I've tested it on SQL Server 2017 and it all seems to be working fine.