### PR TITLE
Pass command timeout to SQL Cover

### DIFF
--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -58,7 +58,7 @@ namespace SQLCover
             _logging = logging;
             _debugger = debugger;
             _traceType = traceType;
-            _database = new DatabaseGateway(connectionString, databaseName);
+            _database = new DatabaseGateway(connectionString, databaseName, commandTimeout);
             _source = new DatabaseSourceGateway(_database);
         }
 

--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -45,7 +45,7 @@ namespace SQLCover
         {
         }
 
-        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType)
+        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType, int commandTimeout = 30)
         {
             if (debugger)
                 Debugger.Launch();

--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -112,7 +112,7 @@ namespace SQLCover
                 Console.WriteLine(message, args);
         }
 
-        public CoverageResult Cover(string command, int timeOut =30)
+        public CoverageResult Cover(string command)
         {
 
         Debug("Starting Code Coverage");
@@ -128,7 +128,7 @@ namespace SQLCover
 
             try
             {
-                _database.Execute(command, timeOut); //todo read messages or rowcounts or something
+                _database.Execute(command); //todo read messages or rowcounts or something
             }
             catch (System.Data.SqlClient.SqlException e)
             {

--- a/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
+++ b/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Data.SqlClient;
+
+namespace SQLCover.Gateway
+{
+    internal class CommandWrapper
+
+    {
+        private readonly string _connectionString;
+        private readonly string _command;
+        private readonly int _timeout;
+
+        public CommandWrapper(string connectionString, string command, int timeout = 30)
+        {
+            _connectionString = connectionString;
+            _command = command;
+            _timeout = timeout;
+        }
+
+        private T OpenConnectionAndDo<T>(Func<SqlCommand,T> func)
+        {
+            using (var connection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(_command, connection))
+            {
+                command.CommandTimeout = _timeout;
+                connection.Open();
+                return func(command);
+            }
+        }
+
+        public int ExecuteNonQuery() => OpenConnectionAndDo(command => command.ExecuteNonQuery());
+
+        public SqlDataReader ExecuteReader() => OpenConnectionAndDo(command => command.ExecuteReader());
+
+        public object ExecuteScalar() => OpenConnectionAndDo(command => command.ExecuteScalar());
+    }
+}

--- a/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
+++ b/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
@@ -17,6 +17,10 @@ namespace SQLCover.Gateway
             _timeout = timeout;
         }
 
+        public CommandWrapper(SqlConnectionStringBuilder connectionStringBuilder, string command, int timeout = 30) :
+            this(connectionStringBuilder.ToString(), command, timeout)
+        { }
+
         private T OpenConnectionAndDo<T>(Func<SqlCommand,T> func)
         {
             using (var connection = new SqlConnection(_connectionString))

--- a/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
+++ b/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
@@ -10,7 +10,7 @@ namespace SQLCover.Gateway
         private readonly string _command;
         private readonly int _timeout;
 
-        public CommandWrapper(string connectionString, string command, int timeout = 30)
+        private CommandWrapper(string connectionString, string command, int timeout)
         {
             _connectionString = connectionString;
             _command = command;

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -32,9 +32,8 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                using (var cmd = conn.CreateCommand())
+                using (var cmd = new SqlCommand(query, conn))
                 {
-                    cmd.CommandText = query;
                     return cmd.ExecuteScalar().ToString();
                 }
             }
@@ -45,9 +44,8 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                using (var cmd = conn.CreateCommand())
+                using (var cmd = new SqlCommand(query, conn))
                 {
-                    cmd.CommandText = query;
                     using (var reader = cmd.ExecuteReader())
                     {
                         var ds = new DataTable();
@@ -63,9 +61,8 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                using (var cmd = conn.CreateCommand())
+                using (var cmd = new SqlCommand(query, conn))
                 {
-                    cmd.CommandText = query;
                     using (var reader = cmd.ExecuteReader())
                     {
                         var ds = new DataTable();
@@ -104,9 +101,8 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                using (var cmd = conn.CreateCommand())
+                using (var cmd = new SqlCommand(command, conn))
                 {
-                    cmd.CommandText = command;
                     cmd.CommandTimeout = timeOut;
                     cmd.ExecuteNonQuery();
                 }

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -7,7 +7,6 @@ namespace SQLCover.Gateway
 {
     public class DatabaseGateway
     {
-        private readonly string _connectionString;
         private readonly string _databaseName;
         private readonly int _commandTimeout;
         private readonly SqlConnectionStringBuilder _connectionStringBuilder;
@@ -20,7 +19,6 @@ namespace SQLCover.Gateway
         }
         public DatabaseGateway(string connectionString, string databaseName, int commandTimeout = 30)
         {
-            _connectionString = connectionString;
             _databaseName = databaseName;
             _commandTimeout = commandTimeout;
             _connectionStringBuilder =
@@ -29,13 +27,13 @@ namespace SQLCover.Gateway
 
         public virtual string GetString(string query)
         {
-            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
             return command.ExecuteScalar().ToString();
         }
 
         public virtual DataTable GetRecords(string query)
         {
-            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
             using (var reader = command.ExecuteReader())
             {
                 var ds = new DataTable();
@@ -46,7 +44,7 @@ namespace SQLCover.Gateway
 
         public virtual DataTable GetTraceRecords(string query)
         {
-            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
             using (var reader = command.ExecuteReader())
             {
                 var ds = new DataTable();
@@ -80,7 +78,7 @@ namespace SQLCover.Gateway
 
         public void Execute(string query)
         {
-            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
             command.ExecuteNonQuery();
         }
     }

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -96,12 +96,12 @@ namespace SQLCover.Gateway
             }
         }
 
-        public void Execute(string command, int timeOut)
+        public void Execute(string query, int timeOut = 30)
         {
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                using (var cmd = new SqlCommand(command, conn))
+                using (var cmd = new SqlCommand(query, conn))
                 {
                     cmd.CommandTimeout = timeOut;
                     cmd.ExecuteNonQuery();

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -9,6 +9,7 @@ namespace SQLCover.Gateway
     {
         private readonly string _connectionString;
         private readonly string _databaseName;
+        private readonly int _commandTimeout;
         private readonly SqlConnectionStringBuilder _connectionStringBuilder;
 
         public string DataSource { get { return _connectionStringBuilder.DataSource; } }
@@ -17,10 +18,11 @@ namespace SQLCover.Gateway
         {
             //for mocking.
         }
-        public DatabaseGateway(string connectionString, string databaseName)
+        public DatabaseGateway(string connectionString, string databaseName, int commandTimeout = 30)
         {
             _connectionString = connectionString;
             _databaseName = databaseName;
+            _commandTimeout = commandTimeout;
             _connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
         }
 

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -29,84 +29,59 @@ namespace SQLCover.Gateway
 
         public virtual string GetString(string query)
         {
-            using (var conn = new SqlConnection(_connectionString))
-            {
-                conn.Open();
-                using (var cmd = new SqlCommand(query, conn))
-                {
-                    return cmd.ExecuteScalar().ToString();
-                }
-            }
+            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            return command.ExecuteScalar().ToString();
         }
 
         public virtual DataTable GetRecords(string query)
         {
-            using (var conn = new SqlConnection(_connectionString))
+            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            using (var reader = command.ExecuteReader())
             {
-                conn.Open();
-                using (var cmd = new SqlCommand(query, conn))
-                {
-                    using (var reader = cmd.ExecuteReader())
-                    {
-                        var ds = new DataTable();
-                        ds.Load(reader);
-                        return ds;
-                    }
-                }
+                var ds = new DataTable();
+                ds.Load(reader);
+                return ds;
             }
         }
 
         public virtual DataTable GetTraceRecords(string query)
         {
-            using (var conn = new SqlConnection(_connectionString))
+            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
+            using (var reader = command.ExecuteReader())
             {
-                conn.Open();
-                using (var cmd = new SqlCommand(query, conn))
+                var ds = new DataTable();
+                ds.Columns.Add(new DataColumn("xml"));
+                while (reader.Read())
                 {
-                    using (var reader = cmd.ExecuteReader())
-                    {
-                        var ds = new DataTable();
-                        ds.Columns.Add(new DataColumn("xml"));
-                        while (reader.Read())
-                        {
-                            XmlDocument xml = new XmlDocument();
-                            xml.LoadXml(reader[0].ToString());
-                             
-                            var root = xml.SelectNodes("/event").Item(0);
+                    XmlDocument xml = new XmlDocument();
+                    xml.LoadXml(reader[0].ToString());
+                     
+                    var root = xml.SelectNodes("/event").Item(0);
 
-                            var objectId = xml.SelectNodes("/event/data[@name='object_id']").Item(0);
-                            var offset = xml.SelectNodes("/event/data[@name='offset']").Item(0);
-                            var offsetEnd = xml.SelectNodes("/event/data[@name='offset_end']").Item(0);
+                    var objectId = xml.SelectNodes("/event/data[@name='object_id']").Item(0);
+                    var offset = xml.SelectNodes("/event/data[@name='offset']").Item(0);
+                    var offsetEnd = xml.SelectNodes("/event/data[@name='offset_end']").Item(0);
 
-                            root.RemoveAll();
-                                 
-                            root.AppendChild(objectId);
-                            root.AppendChild(offset);
-                            root.AppendChild(offsetEnd);
+                    root.RemoveAll();
+                         
+                    root.AppendChild(objectId);
+                    root.AppendChild(offset);
+                    root.AppendChild(offsetEnd);
 
-                            var row = ds.NewRow();
-                            row["xml"] = root.OuterXml;
-                            ds.Rows.Add(row);
+                    var row = ds.NewRow();
+                    row["xml"] = root.OuterXml;
+                    ds.Rows.Add(row);
 
-                        }
-
-                        return ds;
-                    }
                 }
+
+                return ds;
             }
         }
 
         public void Execute(string query, int timeOut = 30)
         {
-            using (var conn = new SqlConnection(_connectionString))
-            {
-                conn.Open();
-                using (var cmd = new SqlCommand(query, conn))
-                {
-                    cmd.CommandTimeout = timeOut;
-                    cmd.ExecuteNonQuery();
-                }
-            }
+            var command = new CommandWrapper(_connectionString, query, timeOut);
+            command.ExecuteNonQuery();
         }
     }
 }

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -78,9 +78,9 @@ namespace SQLCover.Gateway
             }
         }
 
-        public void Execute(string query, int timeOut = 30)
+        public void Execute(string query)
         {
-            var command = new CommandWrapper(_connectionString, query, timeOut);
+            var command = new CommandWrapper(_connectionString, query, _commandTimeout);
             command.ExecuteNonQuery();
         }
     }

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -12,7 +12,7 @@ namespace SQLCover.Gateway
         private readonly int _commandTimeout;
         private readonly SqlConnectionStringBuilder _connectionStringBuilder;
 
-        public string DataSource { get { return _connectionStringBuilder.DataSource; } }
+        public string DataSource => _connectionStringBuilder.DataSource;
 
         public DatabaseGateway()
         {

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -23,7 +23,8 @@ namespace SQLCover.Gateway
             _connectionString = connectionString;
             _databaseName = databaseName;
             _commandTimeout = commandTimeout;
-            _connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
+            _connectionStringBuilder =
+                new SqlConnectionStringBuilder(connectionString) {InitialCatalog = _databaseName};
         }
 
         public virtual string GetString(string query)
@@ -31,7 +32,6 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                conn.ChangeDatabase(_databaseName);
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = query;
@@ -45,7 +45,6 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                conn.ChangeDatabase(_databaseName);
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = query;
@@ -64,7 +63,6 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                conn.ChangeDatabase(_databaseName);
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = query;
@@ -106,7 +104,6 @@ namespace SQLCover.Gateway
             using (var conn = new SqlConnection(_connectionString))
             {
                 conn.Open();
-                conn.ChangeDatabase(_databaseName);
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = command;

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -27,13 +27,15 @@ namespace SQLCover.Gateway
 
         public virtual string GetString(string query)
         {
-            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
-            return command.ExecuteScalar().ToString();
+            using (var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout))
+            {
+                return command.ExecuteScalar().ToString();
+            }
         }
 
         public virtual DataTable GetRecords(string query)
         {
-            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
+            using (var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout))
             using (var reader = command.ExecuteReader())
             {
                 var ds = new DataTable();
@@ -44,7 +46,7 @@ namespace SQLCover.Gateway
 
         public virtual DataTable GetTraceRecords(string query)
         {
-            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
+            using (var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout))
             using (var reader = command.ExecuteReader())
             {
                 var ds = new DataTable();
@@ -53,7 +55,7 @@ namespace SQLCover.Gateway
                 {
                     XmlDocument xml = new XmlDocument();
                     xml.LoadXml(reader[0].ToString());
-                     
+                 
                     var root = xml.SelectNodes("/event").Item(0);
 
                     var objectId = xml.SelectNodes("/event/data[@name='object_id']").Item(0);
@@ -61,7 +63,7 @@ namespace SQLCover.Gateway
                     var offsetEnd = xml.SelectNodes("/event/data[@name='offset_end']").Item(0);
 
                     root.RemoveAll();
-                         
+                     
                     root.AppendChild(objectId);
                     root.AppendChild(offset);
                     root.AppendChild(offsetEnd);
@@ -78,8 +80,10 @@ namespace SQLCover.Gateway
 
         public void Execute(string query)
         {
-            var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout);
-            command.ExecuteNonQuery();
+            using (var command = new CommandWrapper(_connectionStringBuilder, query, _commandTimeout))
+            {
+                command.ExecuteNonQuery();
+            }
         }
     }
 }

--- a/src/SQLCover/SQLCover/SQLCover.csproj
+++ b/src/SQLCover/SQLCover/SQLCover.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Gateway\CommandWrapper.cs" />
     <Compile Include="Objects\Batch.cs" />
     <Compile Include="CodeCoverage.cs" />
     <Compile Include="CoverageResult.cs" />

--- a/src/SQLCover/SQLCover/Trace/TraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/TraceController.cs
@@ -25,12 +25,12 @@ namespace SQLCover.Trace
         public abstract void Drop();
 
 
-        protected void RunScript(string query, string error, int timeout =30)
+        protected void RunScript(string query, string error)
         {
             var script = GetScript(query);
             try
             {
-                Gateway.Execute(script, timeout);
+                Gateway.Execute(script);
             }
             catch (Exception ex)
             {

--- a/src/SQLCover/test/SQLCover.IntegrationTests/CodeCoverage_IntegrationTests.cs
+++ b/src/SQLCover/test/SQLCover.IntegrationTests/CodeCoverage_IntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Diagnostics;
 using NUnit.Framework;
+using SQLCover.Trace;
 
 namespace SQLCover.IntegrationTests
 {
@@ -65,10 +66,10 @@ namespace SQLCover.IntegrationTests
         public void TimeoutCalling_Cover_Fails_With_Timeout_Exception()
         {
             var coverage = new CodeCoverage(TestServerConnectionString, TestDatabaseName,
-                new[] {".*tSQLt.*", ".*proc.*"});
+                new[] {".*tSQLt.*", ".*proc.*"}, false, false, TraceControllerType.Default, 1);
             try
             {
-                coverage.Cover("WAITFOR DELAY '1:00:00'", 1);
+                coverage.Cover("WAITFOR DELAY '1:00:00'");
             }
             catch (System.Data.SqlClient.SqlException e)
             {

--- a/src/SQLCover/test/SQLCover.IntegrationTests/DatabaseSource_IntegrationTests.cs
+++ b/src/SQLCover/test/SQLCover.IntegrationTests/DatabaseSource_IntegrationTests.cs
@@ -60,13 +60,13 @@ namespace SQLCover.IntegrationTests
         [Test]
         public void Doesnt_Die_When_Finding_Encrypted_Stored_Procedures()
         {
-            var databaseGateway = new DatabaseGateway(TestServerConnectionString, TestDatabaseName);
+            var databaseGateway = new DatabaseGateway(TestServerConnectionString, TestDatabaseName, 15);
             databaseGateway.Execute(@"if not exists (select * from sys.procedures where name = 'enc')
 begin
 	exec sp_executesql N'create procedure enc with encryption 
 	as
 	select 100;'
-end", 15);
+end");
             var source = new DatabaseSourceGateway(databaseGateway);
             var batches = source.GetBatches(null);
             
@@ -87,13 +87,13 @@ end", 15);
         [Test]
         public void Shows_Warnings_When_Definition_Not_Available()
         {
-            var databaseGateway = new DatabaseGateway(TestServerConnectionString, TestDatabaseName);
+            var databaseGateway = new DatabaseGateway(TestServerConnectionString, TestDatabaseName, 15);
             databaseGateway.Execute(@"if not exists (select * from sys.procedures where name = 'enc')
 begin
 	exec sp_executesql N'create procedure enc with encryption 
 	as
 	select 100;'
-end", 15);
+end");
             var source = new DatabaseSourceGateway(databaseGateway);
             var warnings = source.GetWarnings();
             Assert.IsTrue(


### PR DESCRIPTION
This PR allows the passing of a command timeout to SQL Cover.

I tested this manually via nobbling the SQL Cover queries to use [WAITFOR](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/waitfor-transact-sql?view=sql-server-2017) to make the query take a precise length of time. I set the command timeout to be less than this and watched it error out. I then increased the command timeout to be longer than the time it would take to execute the query and watched it complete successfully.