### PR TITLE
Allow passing an `IDbConnection` instead of a connection string

### DIFF
--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -45,11 +46,24 @@ namespace SQLCover
         {
         }
 
-        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType, int commandTimeout = 30)
+        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType, int commandTimeout = 30) : this(databaseName, excludeFilter, logging, debugger, traceType, commandTimeout)
+        {
+            _database = new DatabaseGateway(connectionString, databaseName, commandTimeout);
+            _source = new DatabaseSourceGateway(_database);
+        }
+
+        public CodeCoverage(IDbConnection dbConnection, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType, int commandTimeout = 30) : this(databaseName, excludeFilter, logging, debugger, traceType, commandTimeout)
+        {
+            _database = new DatabaseGateway(dbConnection, databaseName, commandTimeout);
+            _source = new DatabaseSourceGateway(_database);
+        }
+
+        private CodeCoverage(string databaseName, string[] excludeFilter, bool logging, bool debugger,
+            TraceControllerType traceType, int commandTimeout = 30)
         {
             if (debugger)
                 Debugger.Launch();
-            
+
             _databaseName = databaseName;
             if (excludeFilter == null)
                 excludeFilter = new string[0];
@@ -58,9 +72,9 @@ namespace SQLCover
             _logging = logging;
             _debugger = debugger;
             _traceType = traceType;
-            _database = new DatabaseGateway(connectionString, databaseName, commandTimeout);
-            _source = new DatabaseSourceGateway(_database);
         }
+
+
 
         public bool Start()
         {

--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -227,7 +227,7 @@ namespace SQLCover
         private void GenerateResults(List<string> filter, List<string> xml)
         {
             var batches = _source.GetBatches(filter);
-            _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource);
+            _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource());
         }
 
         public CoverageResult Results()

--- a/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
+++ b/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
@@ -31,7 +31,11 @@ namespace SQLCover.Gateway
 
         private T OpenConnectionAndDo<T>(Func<T> func)
         {
-            _connection.Open();
+            if (_connection.State == ConnectionState.Closed)
+            {
+                _connection.Open();
+            }
+
             return func();
         }
 

--- a/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
+++ b/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
@@ -44,7 +44,6 @@ namespace SQLCover.Gateway
         public void Dispose()
         {
             _command?.Dispose();
-            _connection?.Dispose();
         }
     }
 }

--- a/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
+++ b/src/SQLCover/SQLCover/Gateway/CommandWrapper.cs
@@ -1,23 +1,33 @@
 ﻿using System;
+using System.Data;
 using System.Data.SqlClient;
 
 namespace SQLCover.Gateway
 {
     internal class CommandWrapper : IDisposable
-
     {
-        private readonly SqlCommand _command;
-        private readonly SqlConnection _connection;
+        private readonly IDbCommand _command;
+        private readonly IDbConnection _connection;
 
         private CommandWrapper(string connectionString, string command, int timeout)
         {
             _connection = new SqlConnection(connectionString);
-            _command = new SqlCommand(command, _connection) {CommandTimeout = timeout};
+            _command = _connection.CreateCommand();
+            _command.CommandText = command;
+            _command.CommandTimeout = timeout;
         }
 
         public CommandWrapper(SqlConnectionStringBuilder connectionStringBuilder, string command, int timeout = 30) :
             this(connectionStringBuilder.ToString(), command, timeout)
         { }
+
+        public CommandWrapper(IDbConnection dbConnection, string command, int timeout = 30)
+        {
+            _connection = dbConnection;
+            _command = _connection.CreateCommand();
+            _command.CommandText = command;
+            _command.CommandTimeout = timeout;
+        }
 
         private T OpenConnectionAndDo<T>(Func<T> func)
         {
@@ -27,7 +37,7 @@ namespace SQLCover.Gateway
 
         public int ExecuteNonQuery() => OpenConnectionAndDo(() => _command.ExecuteNonQuery());
 
-        public SqlDataReader ExecuteReader() => OpenConnectionAndDo(() => _command.ExecuteReader());
+        public IDataReader ExecuteReader() => OpenConnectionAndDo(() => _command.ExecuteReader());
 
         public object ExecuteScalar() => OpenConnectionAndDo(() => _command.ExecuteScalar());
 

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -11,7 +11,11 @@ namespace SQLCover.Gateway
         private readonly int _commandTimeout;
         private readonly SqlConnectionStringBuilder _connectionStringBuilder;
 
-        public string DataSource => _connectionStringBuilder.DataSource;
+        public string DataSource()
+        {
+            var csb = _connectionStringBuilder?? new SqlConnectionStringBuilder(_dbConnection.ConnectionString);
+            return csb.DataSource;
+        }
 
         public DatabaseGateway()
         {

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -1,5 +1,7 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Data.SqlClient;
+using System.Linq;
 using System.Xml;
 
 namespace SQLCover.Gateway
@@ -13,8 +15,15 @@ namespace SQLCover.Gateway
 
         public string DataSource()
         {
-            var csb = _connectionStringBuilder?? new SqlConnectionStringBuilder(_dbConnection.ConnectionString);
-            return csb.DataSource;
+            var parameters = _dbConnection.ConnectionString.Split(';');
+            var parameter = parameters.FirstOrDefault(p => IsParameter(p, "Server") || IsParameter(p, "Data Source") || IsParameter(p, "DataSource"))?
+                .Split('=')[1]
+                .TrimStart(' ').
+                TrimEnd(' ');
+
+            return parameter ?? string.Empty;
+
+            bool IsParameter(string input, string param) => input.StartsWith(param, StringComparison.InvariantCultureIgnoreCase);
         }
 
         public DatabaseGateway()

--- a/src/SQLCover/SQLCover/Properties/AssemblyInfo.cs
+++ b/src/SQLCover/SQLCover/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.25.0")]
-[assembly: AssemblyFileVersion("1.0.25.0")]
+[assembly: AssemblyVersion("1.0.26.0")]
+[assembly: AssemblyFileVersion("1.0.26.0")]


### PR DESCRIPTION
Added a path to allow passing an `IDbConnection` to the `CodeCoverage` class. This enables us to pass in an Azure MFA connection from SQL Test, without having to re-authorize the connection separately.