### PR TITLE
Dev/TBE-68 - Changes required for adding object filter in SQL Test. 

### DIFF
--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -39,7 +39,7 @@ namespace SQLCover.Source
         }
 
 
-public IEnumerable<Batch> GetBatches(List<string> objectFilter)
+public IEnumerable<Batch> GetBatches(List<string> objectFilter, List<string> filteredObjects = null)
         {
             // object_name() can return NULL on permissions failures
             var table =
@@ -54,6 +54,12 @@ where object_id not in (select object_id from sys.objects where type = 'IF')
             
             var version = GetVersion();
             var excludedObjects = GetExcludedObjects();
+
+            if (filteredObjects != null)
+            {
+                excludedObjects.AddRange(filteredObjects);
+            }
+
             if(objectFilter == null)
                 objectFilter = new List<string>();
 
@@ -64,7 +70,7 @@ where object_id not in (select object_id from sys.objects where type = 'IF')
                 var quoted = (bool) row["uses_quoted_identifier"];
                 
                 var name = row["object_name"] as string;
-                
+
                 if (name != null && row["object_id"] as int? != null &&  DoesNotMatchFilter(name, objectFilter, excludedObjects))
                 {
                     batches.Add(
@@ -173,7 +179,7 @@ where schema_id in (
 
             foreach (var filter in excludedObjects)
             {
-                if (filter == lowerName)
+                if (filter == lowerName || filter == name)
                     return false;
             }
             

--- a/src/SQLCover/SQLCover/Source/SourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/SourceGateway.cs
@@ -6,7 +6,7 @@ namespace SQLCover.Source
     public interface SourceGateway
     {
         SqlServerVersion GetVersion();
-        IEnumerable<Batch> GetBatches(List<string> objectFilter);
+        IEnumerable<Batch> GetBatches(List<string> objectFilter,List<string> filteredObjects = null);
         string GetWarnings();
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

 - Added parameter and private property for filtering certain objects, adjusted Interface.
 
 - Added a function for returning all batches object names and modified `GenerateResults()` parameters required to fit new filtered objects parameter.
 
 - Changed the condition flag in `DoesNotMatchFilter()` function inside `DatabaseSourceGateway.cs` to cover new filtered objects as well.

How to test this code:
 - Create any proper Sql CodeCoverage (or use existing SQL Test one) and start it by initiating `Stop()` function.
 the recieving call from `GetBatchesObjectNames()` should contain list of all object names, which then can be passed or (the list cant be modified) into  new CodeCoverage object to filter certain batches changing the result.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2014
 - SQL Server 2016
