### PR TITLE
Fixed an issue where CodeCoverage would fail on Azure ActiveDirectory authentication.

### DIFF
--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -54,7 +54,7 @@ namespace SQLCover.Gateway
         {
             using (var command = CreateCommand(query))
             {
-                return command.ExecuteScalar().ToString();
+                return command.ExecuteScalar()?.ToString();
             }
         }
 

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -22,8 +22,8 @@ namespace SQLCover.Source
         public SqlServerVersion GetVersion()
         {
             var compatibilityString = _databaseGateway.GetString("select compatibility_level from sys.databases where name = DB_NAME();");
-            SqlServerVersion res;
-            if (Enum.TryParse(string.Format("Sql{0}", compatibilityString), out res))
+
+            if (Enum.TryParse($"Sql{compatibilityString}", out SqlServerVersion res))
             {
                 return res;
             }

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -21,7 +21,7 @@ namespace SQLCover.Source
 
         public SqlServerVersion GetVersion()
         {
-            var compatibilityString = _databaseGateway.GetString("select compatibility_level from sys.databases where database_id = db_id();");
+            var compatibilityString = _databaseGateway.GetString("select compatibility_level from sys.databases where name = DB_NAME();");
             SqlServerVersion res;
             if (Enum.TryParse(string.Format("Sql{0}", compatibilityString), out res))
             {

--- a/src/SQLCover/test/SQLCover.UnitTests/Source/DatabaseSourceGatewayTests.cs
+++ b/src/SQLCover/test/SQLCover.UnitTests/Source/DatabaseSourceGatewayTests.cs
@@ -27,6 +27,15 @@ namespace SQLCover.UnitTests.Source
             Assert.AreEqual(expected, source.GetVersion());
         }
 
+        [Test]
+        public void GetVersion_WhenFailedToRetrieveValue_ReturnsSql140()
+        {
+            var gateway = new Mock<DatabaseGateway>();
+            gateway.Setup(x => x.GetString(It.IsAny<string>())).Returns((string)null);
+            var source = new DatabaseSourceGateway(gateway.Object);
+            Assert.AreEqual(SqlServerVersion.Sql140, source.GetVersion());
+        }
+
         private Mock<DatabaseGateway> GetGateway(SqlServerVersion expected)
         {
             var gateway = new Mock<DatabaseGateway>();


### PR DESCRIPTION
# Fixes

Changes proposed in this pull request:
 - Handled null return on retrieving compability level from a database.
 - Refactored.
 - Added a test.

How to test this code:
 - Open SSMS with SQL test, Azure AD connection and run code coverage, with this change implemented.
 
 Change context:
 Previous query:
 ```sql
 select compatibility_level from sys.databases where database_id = db_id();
 ```
 works fine for any connection besides ones based azure db, on azure such selection returns `NULL`.
 
 Current query:
 ```sql
 select compatibility_level from sys.databases where name = DB_NAME();
 ```
 works fine for both azure and sqlserver connections.
 
 
 
Before Change:
![obraz](https://github.com/red-gate/sqlcover/assets/107455395/c03f021e-daca-496a-a16a-33e1e307010e)

After Change:
![obraz](https://github.com/red-gate/sqlcover/assets/107455395/9ff52ff6-4524-4131-abba-0e767572fe4b)



Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - Azure SQL DB
 - SqlServer2022
