### PR TITLE
Update Create trace logic and optimized result calculation

### DIFF
--- a/nuspec/SqlCover.nuspec
+++ b/nuspec/SqlCover.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>RedGate.ThirdParty.SqlCover</id>
-    <version>1.0.30.0</version>
+    <version>1.0.31.0</version>
     <title>SQL Cover</title>
     <authors>Ed Elliott</authors>
     <owners>Ed Elliott</owners>

--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -232,12 +232,14 @@ namespace SQLCover
             _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource());
         }
 
-        public IEnumerable<string> GetBatchesObjectNames()
+        public List<string> GetBatchesObjectNames()
         {
+            var batchesList = new List<string>();
             foreach (var batch in _source.GetBatches(null))
             {
-                yield return batch.ObjectName;
+                batchesList.Add(batch.ObjectName);
             }
+            return batchesList;
         }
 
         public CoverageResult Results()

--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -232,14 +232,12 @@ namespace SQLCover
             _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource());
         }
 
-        public List<string> GetBatchesObjectNames()
+        public IEnumerable<string> GetBatchesObjectNames()
         {
-            var batchesList = new List<string>();
             foreach (var batch in _source.GetBatches(null))
             {
-                batchesList.Add(batch.ObjectName);
+                yield return batch.ObjectName;
             }
-            return batchesList;
         }
 
         public CoverageResult Results()

--- a/src/SQLCover/SQLCover/Properties/AssemblyInfo.cs
+++ b/src/SQLCover/SQLCover/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.30.0")]
-[assembly: AssemblyFileVersion("1.0.30.0")]
+[assembly: AssemblyVersion("1.0.31.0")]
+[assembly: AssemblyFileVersion("1.0.31.0")]

--- a/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
@@ -10,10 +10,12 @@ namespace SQLCover.Trace
     {
         
         private const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON SERVER 
-ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
+ADD EVENT sqlserver.sp_statement_completed(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
 ADD TARGET package0.asynchronous_file_target(
-     SET filename='{2}')
-WITH (MAX_MEMORY=100 MB,EVENT_RETENTION_MODE=NO_EVENT_LOSS,MAX_DISPATCH_LATENCY=1 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 
+     SET filename='{2}',
+        max_file_size = 10240,
+        max_rollover_files = 20)
+WITH (MAX_MEMORY=256 MB,EVENT_RETENTION_MODE=NO_EVENT_LOSS,MAX_DISPATCH_LATENCY=5 SECONDS,MAX_EVENT_SIZE=256 MB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 
 ";
 
         private const string StartTraceFormat = @"alter event session [{0}] on server state = start


### PR DESCRIPTION
Changes proposed in this pull request:
- Optimized the result calculation logic by switching to `IEnumerable<string>` and using `yield return`.
- Increased the file size limit and updated the session event configuration for SQLCover. Each log file will now be 20 GB, and up to 10 such files can be generated during testing, allowing us to store sufficient data and calculate coverage accurately.

How to test this code:
 - Consume the nupkg in SQLTest and run Tests with Code coverage ON.
 Have tested the changes with prerelease version `1.0.31.2-codecoverage`.

Has been tested on (remove any that don't apply):
 - SQL Server 2022
